### PR TITLE
feat: 그룹 만들기 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,13 @@
 import { Route, Routes } from "react-router-dom";
 
 import PublicGroup from "@pages/PublicGroup/PublicGroup";
+import CreateGroupPage from "@pages/CreateGroup/CreateGroupPage";
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<PublicGroup />} />
+      <Route path="/create-group" element={<CreateGroupPage />} />
     </Routes>
   );
 }

--- a/src/assets/eye-icon.svg
+++ b/src/assets/eye-icon.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo
+Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 2L22 22" stroke="current" stroke-width="2" stroke-linecap="round"
+        stroke-linejoin="round" />
+    <path
+        d="M6.71277 6.7226C3.66479 8.79527 2 12 2 12C2 12 5.63636 19 12 19C14.0503 19 15.8174 18.2734 17.2711 17.2884M11 5.05822C11.3254 5.02013 11.6588 5 12 5C18.3636 5 22 12 22 12C22 12 21.3082 13.3317 20 14.8335"
+        stroke="current" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path
+        d="M14 14.2362C13.4692 14.7112 12.7684 15.0001 12 15.0001C10.3431 15.0001 9 13.657 9 12.0001C9 11.1764 9.33193 10.4303 9.86932 9.88818"
+        stroke="current" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/src/layout/Header/Header.jsx
+++ b/src/layout/Header/Header.jsx
@@ -11,7 +11,9 @@ const Header = () => {
         <Link to="/">
           <MainLogo src={mainLogo} alt="조각집 메인 로고" />
         </Link>
-        <CreateGroupButton>그룹 만들기</CreateGroupButton>
+        <Link to="/create-group">
+          <CreateGroupButton>그룹 만들기</CreateGroupButton>
+        </Link>
       </HeaderContainer>
     </>
   );

--- a/src/pages/CreateGroup/CreateGroupPage.jsx
+++ b/src/pages/CreateGroup/CreateGroupPage.jsx
@@ -1,0 +1,260 @@
+import { useEffect, useRef, useState } from "react";
+
+import Header from "@layout/Header/Header";
+
+import {
+  CreateGroupButton,
+  CreateGroupPageContainer,
+  CreateGroupSubTitle,
+  CreateGroupTitle,
+  FileSelectButton,
+  GroupImageContainer,
+  GroupImageFileName,
+  GroupImageInput,
+  GroupIntroductionArea,
+  GroupIntroductionContainer,
+  GroupModuleContainer,
+  GroupNameInput,
+  GroupNameInputContainer,
+  GroupPrivacyContainer,
+  GroupPrivacyContent,
+  GroupPrivacyText,
+  InputErrorMessage,
+  PasswordInput,
+  PasswordInputContainer,
+  PasswordVisibleButton,
+  PrivacyToggleContainer,
+  PrivacyToggleInput,
+  StyledEyeIcon,
+} from "./CreateGroupPage.styled";
+
+const CreateGroupPage = () => {
+  const nameInputRef = useRef(null);
+  const groupImageRef = useRef(null);
+  const introInputRef = useRef(null);
+  const passwordInputRef = useRef(null);
+
+  const [nameInputFocused, setNameInputFocused] = useState(false);
+  const [introInputFocused, setIntroInputFocused] = useState(false);
+  const [passwordInputFocused, setPasswordInputFocused] = useState(false);
+
+  const [groupNameValue, setGroupNameValue] = useState("");
+  const [validInputMessage, setValidInputMessage] = useState("");
+  const [groupImageFileName, setGroupImageFileName] = useState("");
+  const [groupIntroduction, setGroupIntroduction] = useState("");
+
+  const [privacyText, setPrivacyText] = useState("비공개");
+
+  const [password, setPassword] = useState("");
+  const [passwordVisible, setPasswordVisible] = useState(false);
+  const [passwordErrorMessage, setPasswordErrorMessage] = useState("");
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (
+        nameInputRef.current &&
+        !nameInputRef.current.contains(e.target) &&
+        e.target !== nameInputRef.current
+      ) {
+        setNameInputFocused(false);
+      }
+
+      if (
+        introInputRef.current &&
+        !introInputRef.current.contains(e.target) &&
+        e.target !== introInputRef.current
+      ) {
+        setIntroInputFocused(false);
+      }
+
+      if (
+        passwordInputRef.current &&
+        !passwordInputRef.current.contains(e.target) &&
+        e.target !== passwordInputRef.current
+      ) {
+        setPasswordInputFocused(false);
+      }
+    };
+
+    const handleInputFocusBlur = (e) => {
+      if (e.target === nameInputRef.current) {
+        setNameInputFocused(e.type === "focus");
+      }
+
+      if (e.target === introInputRef.current) {
+        setIntroInputFocused(e.type === "focus");
+      }
+
+      if (e.target === passwordInputRef.current) {
+        setPasswordInputFocused(e.type === "focus");
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("focus", handleInputFocusBlur, true);
+    document.addEventListener("blur", handleInputFocusBlur, true);
+
+    return () => {
+      document.addEventListener("mousedown", handleClickOutside);
+      document.addEventListener("focus", handleInputFocusBlur, true);
+      document.addEventListener("blur", handleInputFocusBlur, true);
+    };
+  }, [nameInputRef, introInputRef]);
+
+  const handleGroupNameValue = (e) => {
+    const inputValue = e.target.value;
+    setGroupNameValue(inputValue);
+
+    const isValid = /^[a-zA-Z가-힣0-9!@#$%^_]*$/.test(inputValue);
+
+    if (isValid) {
+      setValidInputMessage("");
+    } else {
+      setValidInputMessage("특수문자는 !@#$%^_만 사용하실 수 있습니다.");
+    }
+  };
+
+  const handleGroupImageChange = (e) => {
+    if (e.target.files.length > 0) {
+      setGroupImageFileName(e.target.files[0].name);
+    }
+  };
+
+  const handleFileSelectClick = () => {
+    groupImageRef.current.click();
+  };
+
+  const handleGroupIntroduction = (e) => {
+    setGroupIntroduction(e.target.value);
+  };
+
+  const handlePrivacyText = () => {
+    setPrivacyText((prev) => (prev === "비공개" ? "공개" : "비공개"));
+  };
+
+  const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#]).{8,}$/;
+
+  const handlePassWordValidation = (e) => {
+    const newPassword = e.target.value;
+    setPassword(event.target.value);
+
+    if (newPassword === "") {
+      setPasswordErrorMessage("");
+      return;
+    }
+
+    if (passwordRegex.test(newPassword)) {
+      setPasswordErrorMessage("");
+    } else {
+      setPasswordErrorMessage(
+        "비밀번호는 영문 대문자, 소문자, !@# 중 하나의 특수문자를 포함해야 합니다."
+      );
+    }
+  };
+
+  const togglePasswordVisibility = () => {
+    setPasswordVisible(!passwordVisible);
+  };
+
+  return (
+    <>
+      <Header />
+      <CreateGroupPageContainer>
+        <CreateGroupTitle>그룹 만들기</CreateGroupTitle>
+        <GroupModuleContainer>
+          <CreateGroupSubTitle>그룹명</CreateGroupSubTitle>
+          <GroupNameInputContainer
+            $isFocused={nameInputFocused}
+            $isValid={validInputMessage === ""}
+          >
+            <GroupNameInput
+              onFocus={() => setNameInputFocused(true)}
+              ref={nameInputRef}
+              onChange={handleGroupNameValue}
+              value={groupNameValue}
+              type="text"
+              placeholder="그룹명을 입력해주세요"
+            />
+          </GroupNameInputContainer>
+          <InputErrorMessage $isValid={validInputMessage === ""}>
+            {validInputMessage}
+          </InputErrorMessage>
+        </GroupModuleContainer>
+
+        <GroupModuleContainer>
+          <CreateGroupSubTitle>대표 이미지</CreateGroupSubTitle>
+          <GroupImageContainer>
+            <GroupImageInput
+              type="file"
+              ref={groupImageRef}
+              onChange={handleGroupImageChange}
+            />
+            <GroupImageFileName
+              placeholder="파일을 선택해주세요"
+              value={groupImageFileName}
+              readOnly
+            />
+            <FileSelectButton onClick={handleFileSelectClick}>
+              파일 선택
+            </FileSelectButton>
+          </GroupImageContainer>
+        </GroupModuleContainer>
+
+        <GroupModuleContainer>
+          <CreateGroupSubTitle>그룹 소개</CreateGroupSubTitle>
+          <GroupIntroductionContainer $isFocused={introInputFocused}>
+            <GroupIntroductionArea
+              type="text"
+              placeholder="그룹을 소개해주세요"
+              value={groupIntroduction}
+              ref={introInputRef}
+              onChange={handleGroupIntroduction}
+              onFocus={() => setIntroInputFocused(true)}
+            />
+          </GroupIntroductionContainer>
+        </GroupModuleContainer>
+
+        <GroupPrivacyContainer>
+          <CreateGroupSubTitle>그룹 공개 선택</CreateGroupSubTitle>
+          <GroupPrivacyContent>
+            <GroupPrivacyText>{privacyText}</GroupPrivacyText>
+
+            <PrivacyToggleInput
+              type="checkbox"
+              id="privacy-setting"
+              onChange={handlePrivacyText}
+            />
+            <PrivacyToggleContainer htmlFor="privacy-setting" />
+          </GroupPrivacyContent>
+        </GroupPrivacyContainer>
+
+        <GroupModuleContainer>
+          <CreateGroupSubTitle>비밀번호 생성</CreateGroupSubTitle>
+          <PasswordInputContainer
+            $isFocused={passwordInputFocused}
+            $isValid={passwordErrorMessage === ""}
+          >
+            <PasswordInput
+              type={passwordVisible ? "text" : "password"}
+              placeholder="그룹 비밀번호를 생성해주세요"
+              value={password}
+              onChange={handlePassWordValidation}
+              onFocus={() => setPasswordInputFocused(true)}
+              ref={passwordInputRef}
+            />
+            <PasswordVisibleButton onClick={togglePasswordVisibility}>
+              <StyledEyeIcon $passwordVisible={passwordVisible} />
+            </PasswordVisibleButton>
+            <InputErrorMessage $isValid={passwordErrorMessage === ""}>
+              {passwordErrorMessage}
+            </InputErrorMessage>
+          </PasswordInputContainer>
+        </GroupModuleContainer>
+
+        <CreateGroupButton>만들기</CreateGroupButton>
+      </CreateGroupPageContainer>
+    </>
+  );
+};
+
+export default CreateGroupPage;

--- a/src/pages/CreateGroup/CreateGroupPage.jsx
+++ b/src/pages/CreateGroup/CreateGroupPage.jsx
@@ -11,8 +11,10 @@ import {
   GroupImageContainer,
   GroupImageFileName,
   GroupImageInput,
+  GroupImageValidation,
   GroupIntroductionArea,
   GroupIntroductionContainer,
+  GroupIntroductionWordLimit,
   GroupModuleContainer,
   GroupNameInput,
   GroupNameInputContainer,
@@ -20,6 +22,7 @@ import {
   GroupPrivacyContent,
   GroupPrivacyText,
   InputErrorMessage,
+  IntroCharacterCount,
   PasswordInput,
   PasswordInputContainer,
   PasswordVisibleButton,
@@ -40,7 +43,10 @@ const CreateGroupPage = () => {
 
   const [groupNameValue, setGroupNameValue] = useState("");
   const [validInputMessage, setValidInputMessage] = useState("");
+
   const [groupImageFileName, setGroupImageFileName] = useState("");
+  const [fileSizeErrorMessage, setFileSizeErrorMessage] = useState("");
+
   const [groupIntroduction, setGroupIntroduction] = useState("");
 
   const [privacyText, setPrivacyText] = useState("비공개");
@@ -114,9 +120,24 @@ const CreateGroupPage = () => {
     }
   };
 
+  const MAX_FILE_SIZE = 2 * 1024 * 1024;
+
   const handleGroupImageChange = (e) => {
-    if (e.target.files.length > 0) {
-      setGroupImageFileName(e.target.files[0].name);
+    const selectedFile = e.target.files[0];
+
+    if (selectedFile && selectedFile.size > MAX_FILE_SIZE) {
+      setFileSizeErrorMessage(
+        "파일 용량이 2MB를 초과했습니다. 다른 파일을 선택해주세요."
+      );
+
+      e.target.files = null;
+      setGroupImageFileName("");
+    } else {
+      setFileSizeErrorMessage("");
+
+      if (e.target.files.length > 0) {
+        setGroupImageFileName(e.target.files[0].name);
+      }
     }
   };
 
@@ -124,8 +145,14 @@ const CreateGroupPage = () => {
     groupImageRef.current.click();
   };
 
+  const MAX_INTRO_WORDS = 200;
+
   const handleGroupIntroduction = (e) => {
-    setGroupIntroduction(e.target.value);
+    const { value } = e.target;
+
+    if (value.length <= MAX_INTRO_WORDS) {
+      setGroupIntroduction(value);
+    }
   };
 
   const handlePrivacyText = () => {
@@ -183,35 +210,47 @@ const CreateGroupPage = () => {
 
         <GroupModuleContainer>
           <CreateGroupSubTitle>대표 이미지</CreateGroupSubTitle>
-          <GroupImageContainer>
-            <GroupImageInput
-              type="file"
-              ref={groupImageRef}
-              onChange={handleGroupImageChange}
-            />
-            <GroupImageFileName
-              placeholder="파일을 선택해주세요"
-              value={groupImageFileName}
-              readOnly
-            />
-            <FileSelectButton onClick={handleFileSelectClick}>
-              파일 선택
-            </FileSelectButton>
-          </GroupImageContainer>
+          <GroupImageValidation>
+            <GroupImageContainer $isValid={fileSizeErrorMessage === ""}>
+              <GroupImageInput
+                type="file"
+                accept=".jpg, .jpeg, .png"
+                ref={groupImageRef}
+                onChange={handleGroupImageChange}
+              />
+              <GroupImageFileName
+                placeholder="파일을 선택해주세요"
+                value={groupImageFileName}
+                readOnly
+              />
+              <FileSelectButton onClick={handleFileSelectClick}>
+                파일 선택
+              </FileSelectButton>
+            </GroupImageContainer>
+            <InputErrorMessage $isValid={fileSizeErrorMessage === ""}>
+              {fileSizeErrorMessage}
+            </InputErrorMessage>
+          </GroupImageValidation>
         </GroupModuleContainer>
 
         <GroupModuleContainer>
           <CreateGroupSubTitle>그룹 소개</CreateGroupSubTitle>
-          <GroupIntroductionContainer $isFocused={introInputFocused}>
-            <GroupIntroductionArea
-              type="text"
-              placeholder="그룹을 소개해주세요"
-              value={groupIntroduction}
-              ref={introInputRef}
-              onChange={handleGroupIntroduction}
-              onFocus={() => setIntroInputFocused(true)}
-            />
-          </GroupIntroductionContainer>
+          <GroupIntroductionWordLimit>
+            <GroupIntroductionContainer $isFocused={introInputFocused}>
+              <GroupIntroductionArea
+                type="text"
+                placeholder="그룹을 소개해주세요"
+                maxLength={MAX_INTRO_WORDS}
+                value={groupIntroduction}
+                ref={introInputRef}
+                onChange={handleGroupIntroduction}
+                onFocus={() => setIntroInputFocused(true)}
+              />
+            </GroupIntroductionContainer>
+            <IntroCharacterCount>
+              {groupIntroduction.length}/{MAX_INTRO_WORDS} character
+            </IntroCharacterCount>
+          </GroupIntroductionWordLimit>
         </GroupModuleContainer>
 
         <GroupPrivacyContainer>

--- a/src/pages/CreateGroup/CreateGroupPage.styled.js
+++ b/src/pages/CreateGroup/CreateGroupPage.styled.js
@@ -101,6 +101,29 @@ export const GroupImageContainer = styled.div`
   display: flex;
   align-items: center;
   gap: 10px;
+
+  position: relative;
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 4;
+
+    width: 290px;
+    height: 45px;
+
+    border: 1px solid;
+    border-color: ${({ $isValid }) =>
+      $isValid ? `${colors.gray[200]}` : `${colors.red}`};
+    border-radius: 6px;
+    background-color: transparent;
+
+    opacity: ${({ $isValid }) => ($isValid ? 0 : 1)};
+    transition: opacity 0.1s;
+    pointer-events: none;
+  }
 `;
 
 export const GroupImageInput = styled.input`
@@ -151,6 +174,30 @@ export const GroupIntroductionContainer = styled.div`
     transition: margin-left 0.3s, width 0.35s;
     pointer-events: none;
   }
+`;
+
+export const GroupIntroductionWordLimit = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+export const IntroCharacterCount = styled.p`
+  align-self: flex-end;
+  margin-right: 5px;
+
+  ${({ theme }) => theme.fontStyles.Footnote}
+  color: ${colors.gray[500]};
+`;
+
+export const GroupImageValidation = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 `;
 
 export const GroupIntroductionArea = styled.textarea`

--- a/src/pages/CreateGroup/CreateGroupPage.styled.js
+++ b/src/pages/CreateGroup/CreateGroupPage.styled.js
@@ -1,0 +1,346 @@
+import styled from "styled-components";
+import { colors } from "@styles/theme/colors";
+
+import eyeIcon from "@assets/eye-icon.svg?react";
+
+export const CreateGroupPageContainer = styled.div`
+  width: 100%;
+  margin-top: 142px; // Header 102px + 40px
+  margin-bottom: 141px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 60px;
+
+  color: ${colors.black};
+`;
+
+export const CreateGroupTitle = styled.h2`
+  ${({ theme }) => theme.fontStyles.Header2}
+`;
+
+export const CreateGroupSubTitle = styled.h3`
+  ${({ theme }) => theme.fontStyles.Body4}
+`;
+
+export const GroupModuleContainer = styled.div`
+  width: 400px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+// 그룹명 Section
+
+export const GroupNameInputContainer = styled.div`
+  width: 100%;
+  position: relative;
+  height: 45px;
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 4;
+
+    width: ${({ $isFocused }) => ($isFocused ? "100%" : "0")};
+    height: 45px;
+    margin-left: ${({ $isFocused }) => ($isFocused ? "0" : "-3%")};
+
+    border: 1px solid;
+    border-color: ${({ $isValid }) =>
+      $isValid ? `${colors.black}` : `${colors.red}`};
+    border-radius: 6px;
+    background-color: transparent;
+
+    opacity: ${({ $isFocused }) => ($isFocused ? 1 : 0)};
+    transition: margin-left 0.3s, width 0.35s;
+    pointer-events: none;
+  }
+`;
+
+const GroupInputModule = styled.input`
+  height: 100%;
+  padding: 14px 20px;
+
+  background-color: inherit;
+  border: 1px solid ${colors.gray[200]};
+  border-radius: 6px;
+
+  ${({ theme }) => theme.fontStyles.Caption2}
+  color: ${colors.black};
+
+  &::placeholder {
+    color: ${colors.gray[400]};
+  }
+`;
+
+export const GroupNameInput = styled(GroupInputModule)`
+  width: 100%;
+`;
+
+export const InputErrorMessage = styled.p`
+  /* height: 15px; */
+
+  ${({ theme }) => theme.fontStyles.Footnote}
+  color: ${colors.red};
+
+  opacity: ${({ $isValid }) => ($isValid ? 0 : 1)};
+  transition: opacity 0.3s ease;
+`;
+
+// 대표 이미지 Section
+export const GroupImageContainer = styled.div`
+  width: 100%;
+  height: 45px;
+
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+export const GroupImageInput = styled.input`
+  display: none;
+`;
+
+export const GroupImageFileName = styled(GroupInputModule)`
+  width: 290px;
+
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  pointer-events: none;
+`;
+
+export const FileSelectButton = styled.button`
+  flex-grow: 1;
+  height: 100%;
+
+  background-color: inherit;
+  border: 1px solid ${colors.black};
+  border-radius: 6px;
+`;
+
+// 그룹 소개 Section
+export const GroupIntroductionContainer = styled.div`
+  width: 100%;
+  height: 120px;
+
+  position: relative;
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 4;
+
+    width: ${({ $isFocused }) => ($isFocused ? "100%" : "0")};
+    height: 100%;
+    margin-left: ${({ $isFocused }) => ($isFocused ? "0" : "-3%")};
+
+    border: 1px solid ${colors.black};
+    border-radius: 6px;
+    background-color: transparent;
+
+    opacity: ${({ $isFocused }) => ($isFocused ? 1 : 0)};
+    transition: margin-left 0.3s, width 0.35s;
+    pointer-events: none;
+  }
+`;
+
+export const GroupIntroductionArea = styled.textarea`
+  width: 100%;
+  height: 120px;
+  padding: 14px 20px;
+
+  position: relative;
+
+  resize: none; /* 사용자가 크기를 조절할 수 없게 설정 */
+  background-color: inherit;
+  border: 1px solid ${colors.gray[200]};
+  border-radius: 6px;
+
+  ${({ theme }) => theme.fontStyles.Caption2}
+  color: ${colors.black};
+
+  outline: none;
+
+  &::placeholder {
+    color: ${colors.gray[400]};
+  }
+`;
+
+// 그룹 공개 선택 Section
+
+export const GroupPrivacyContainer = styled(GroupModuleContainer)`
+  gap: 20px;
+`;
+
+export const GroupPrivacyContent = styled.div`
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  gap: 20px;
+
+  position: relative;
+`;
+
+export const GroupPrivacyText = styled.p`
+  width: 40px;
+
+  ${({ theme }) => theme.fontStyles.Caption2}
+`;
+
+export const PrivacyToggleInput = styled.input`
+  position: absolute;
+  top: 0;
+  left: 100px;
+
+  width: 10px;
+  height: 10px;
+  visibility: hidden;
+
+  &:checked + label {
+    background: linear-gradient(
+      to right,
+      #ffffff,
+      #f5f3f5,
+      #ece7ea,
+      #e5dcde,
+      #ddd0d0
+    );
+  }
+
+  &:checked + label::after {
+    transform: translateX(22px);
+    background: linear-gradient(180deg, #ffcc89, #d8860b);
+  }
+`;
+
+export const PrivacyToggleContainer = styled.label`
+  width: 48px;
+  height: 24px;
+
+  position: relative;
+  display: block;
+
+  border-radius: 15px;
+  background: linear-gradient(
+    to left,
+    #5b5b5b,
+    #4f4f4f,
+    #444344,
+    #393838,
+    #2f2d2d
+  );
+
+  box-shadow: inset 0px 5px 15px rgba(0, 0, 0, 0.4),
+    inset 0px -5px 15px rgba(255, 255, 255, 0.4);
+
+  cursor: pointer;
+
+  transition: background 0.3s ease;
+
+  &::after {
+    content: "";
+    width: 20px;
+    height: 20px;
+
+    position: absolute;
+    top: 2px;
+    left: 3px;
+
+    border-radius: 50%;
+    box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.2);
+    background: linear-gradient(180deg, #777, #3a3a3a);
+
+    transition: width 0.2s, background 0.3s, transform 0.25s;
+  }
+
+  &:active::after {
+    width: 21px;
+  }
+`;
+
+// 비밀번호 생성 Section
+export const PasswordInputContainer = styled.div`
+  width: 100%;
+  height: 45px;
+
+  position: relative;
+
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 4;
+
+    width: ${({ $isFocused }) => ($isFocused ? "100%" : "0")};
+    height: 45px;
+    margin-left: ${({ $isFocused }) => ($isFocused ? "0" : "-3%")};
+
+    border: 1px solid;
+    border-color: ${({ $isValid }) =>
+      $isValid ? `${colors.black}` : `${colors.red}`};
+    border-radius: 6px;
+    background-color: transparent;
+
+    opacity: ${({ $isFocused }) => ($isFocused ? 1 : 0)};
+    transition: margin-left 0.3s, width 0.35s;
+    pointer-events: none;
+  }
+`;
+
+export const PasswordInput = styled(GroupInputModule)`
+  width: 100%;
+  ${({ theme }) => theme.fontStyles.Caption2}
+`;
+
+export const PasswordVisibleButton = styled.button`
+  width: 20px;
+  height: 20px;
+
+  position: absolute;
+  top: 12.5px;
+  right: 15px;
+`;
+
+export const StyledEyeIcon = styled(eyeIcon)`
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  width: 100%;
+  height: 100%;
+
+  path {
+    stroke: ${({ $passwordVisible }) =>
+      $passwordVisible ? `${colors.gray[400]}` : `${colors.black}`};
+
+    transition: stroke 0.1s;
+  }
+`;
+
+// 만들기 Button
+
+export const CreateGroupButton = styled.button`
+  width: 400px;
+  height: 50px;
+
+  border-radius: 6px;
+  background-color: ${colors.black};
+
+  ${({ theme }) => theme.fontStyles.Body4}
+  color: ${colors.gray[50]};
+`;

--- a/src/pages/PublicGroup/PublicGroup.jsx
+++ b/src/pages/PublicGroup/PublicGroup.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 
 import {
   CreateGroupButtonLarge,
@@ -118,7 +119,9 @@ const PublicGroup = () => {
           <h2 className="notice-1">등록된 공개 그룹이 없습니다.</h2>
           <h3 className="notice-2">가장 먼저 그룹을 만들어보세요!</h3>
         </NoGroupContainer>
-        <CreateGroupButtonLarge>그룹 만들기</CreateGroupButtonLarge>
+        <Link to="/create-group">
+          <CreateGroupButtonLarge>그룹 만들기</CreateGroupButtonLarge>
+        </Link>
       </PublicGroupContainer>
     </>
   );

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -7,3 +7,7 @@ body {
   font-family: $font-primary;
   background-color: $background-color;
 }
+
+input {
+  outline: none;
+}


### PR DESCRIPTION
## Tasks Done

- 각 Section에 재사용할 수 있는 Flexbox 레이아웃 구현
- 그룹명, 비밀번호, 대표 이미지 파일 Section에 Validation 구현
- 대표 이미지 파일 input 구현 (`.jpg`, `.png`, `.jpeg` 확장자 제한)
- 그룹 소개 Section `<textarea />` 태그로 구현 (글자수 제한, 글자수 렌더링)
- 비밀번호 Hide/Visible 기능 구현

## Related Issues

#4 